### PR TITLE
chore: remove experimental appDir setting

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  experimental: {
-    appDir: true,
-  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- remove experimental appDir from Next.js config

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c18749d6e08328846004c358e51f3d