### PR TITLE
Handle Next.js lockfile patch and cleanup layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next build",
     "start": "next start",
     "lint": "eslint"
   },

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -1,9 +1,0 @@
-export const metadata = { title: "D8" };
-
-export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <html lang="en">
-      <body>{children}</body>
-    </html>
-  );
-}


### PR DESCRIPTION
## Summary
- skip Next.js lockfile patch during build to avoid deployment failure
- remove redundant top-level layout file

## Testing
- `npm run build` *(fails: Cannot find module 'autoprefixer')*

------
https://chatgpt.com/codex/tasks/task_e_68c19910e85c8328a8dd7d3eeb64076e